### PR TITLE
Set up Flask project skeleton with intake form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Flask configuration
+FLASK_SECRET_KEY=change-me
+FLASK_ENV=development
+
+# OpenAI credentials
+OPENAI_API_KEY=sk-...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+instance/
+.env
+.env.*
+!.env.example
+venv/
+.env.local
+.idea/
+.vscode/
+.DS_Store
+
+# Pytest cache
+.pytest_cache/
+
+# Virtual environments
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
 # Proof of concept for Health Team 1
 
-Proof of concept system to provide tumour advice to clinicians for the treatment of breast cancer.
+Proof-of-concept system to provide tumour advice to clinicians for the treatment of breast cancer.
 
+## Project structure
+
+```
+app/
+  __init__.py        # Flask application factory
+  forms.py           # WTForms definitions for the intake workflow
+  routes.py          # HTTP routes and view logic
+  templates/         # Jinja templates for the UI
+config.py            # Environment configuration objects
+run.py               # Development server entrypoint
+requirements.txt     # Python dependencies
+```
+
+Additional folders such as `data/` and `vector_store/` will be created in later steps to support retrieval-augmented generation.
+
+## Getting started
+
+1. Create and activate a Python 3.11 virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy the environment template and populate secrets:
+   ```bash
+   cp .env.example .env
+   ```
+4. Run the development server:
+   ```bash
+   flask --app run:app --debug run
+   ```
+
+The default server listens on http://127.0.0.1:5000/ and exposes a preliminary form for capturing EHR, pathology, and genomic details. Subsequent steps will wire in prompt management, retrieval, and LLM orchestration.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,47 @@
+"""Flask application factory for the Health Team 1 proof of concept."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from flask import Flask
+from dotenv import load_dotenv
+
+
+def create_app(test_config: dict | None = None) -> Flask:
+    """Application factory used by Flask.
+
+    Loads configuration from environment variables, instance config, and an
+    optional ``test_config`` dict. Registers core blueprints and prepares
+    folders used by the application.
+    """
+
+    project_root = Path(__file__).resolve().parent.parent
+    load_dotenv(project_root / ".env")
+
+    app = Flask(__name__, instance_relative_config=True)
+
+    app.config.from_mapping(
+        SECRET_KEY=os.environ.get("FLASK_SECRET_KEY", "dev-secret-key"),
+        OPENAI_API_KEY=os.environ.get("OPENAI_API_KEY"),
+    )
+
+    if test_config is not None:
+        app.config.update(test_config)
+    else:
+        app.config.from_pyfile("config.py", silent=True)
+
+    try:
+        os.makedirs(app.instance_path, exist_ok=True)
+    except OSError:
+        # In containerized deployments the instance folder may already exist.
+        pass
+
+    from .routes import bp as main_bp
+
+    app.register_blueprint(main_bp)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,0 +1,45 @@
+"""WTForms definitions for case intake."""
+from __future__ import annotations
+
+from flask_wtf import FlaskForm
+from wtforms import FieldList, FormField, SelectField, StringField, SubmitField, TextAreaField
+from wtforms.validators import Optional
+
+
+class DemographicsForm(FlaskForm):
+    """Demographics and baseline patient information."""
+
+    patient_id = StringField("Patient ID", validators=[Optional()])
+    age = StringField("Age", validators=[Optional()])
+    sex = SelectField(
+        "Sex",
+        choices=[("female", "Female"), ("male", "Male"), ("other", "Other")],
+        validators=[Optional()],
+    )
+    clinical_notes = TextAreaField("Clinical Notes", validators=[Optional()])
+
+
+class PathologyForm(FlaskForm):
+    """Tumour pathology details."""
+
+    tumour_type = StringField("Tumour Type", validators=[Optional()])
+    stage = StringField("Stage", validators=[Optional()])
+    receptor_status = TextAreaField("Receptor Status", validators=[Optional()])
+
+
+class GenomicsForm(FlaskForm):
+    """Genomic findings for the current case."""
+
+    sequencing_platform = StringField("Sequencing Platform", validators=[Optional()])
+    variants = TextAreaField("Variants", validators=[Optional()])
+
+
+class CaseIntakeForm(FlaskForm):
+    """Aggregate form that collects EHR, pathology, and genomic details."""
+
+    demographics = FormField(DemographicsForm, label="EHR / Demographics")
+    pathology = FormField(PathologyForm, label="Pathology")
+    genomics = FormField(GenomicsForm, label="Genomics")
+    retrieved_case_ids = FieldList(StringField("Retrieved Case ID"), min_entries=0)
+
+    submit = SubmitField("Save Draft")

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,21 @@
+"""Application routes for the Health Team 1 proof of concept."""
+from __future__ import annotations
+
+from flask import Blueprint, render_template
+
+from .forms import CaseIntakeForm
+
+bp = Blueprint("main", __name__)
+
+
+@bp.route("/", methods=["GET", "POST"])
+def index():
+    """Render the landing page with the intake form."""
+    form = CaseIntakeForm()
+
+    if form.validate_on_submit():
+        # Placeholder: logic to persist drafts or trigger LLM interactions will
+        # be implemented in later steps.
+        pass
+
+    return render_template("index.html", form=form)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Health Team 1 &mdash; Breast Cancer Support</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+      <div class="container-fluid">
+        <span class="navbar-brand">Health Team 1</span>
+      </div>
+    </nav>
+
+    <main class="container py-4">
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-lg-8 mx-auto">
+      <h1 class="mb-4">Breast Cancer Case Intake</h1>
+      <p class="lead">
+        Use this form to capture electronic health record, pathology, and genomic
+        information for the current case. Later steps will augment this
+        submission with retrieval-augmented generation and LLM validation.
+      </p>
+      <form method="post" novalidate>
+        {{ form.hidden_tag() }}
+
+        <section class="mb-4">
+          <h2 class="h4">EHR / Demographics</h2>
+          <div class="mb-3">
+            {{ form.demographics.patient_id.label(class="form-label") }}
+            {{ form.demographics.patient_id(class="form-control", placeholder="Internal identifier") }}
+          </div>
+          <div class="row">
+            <div class="col-md-6 mb-3">
+              {{ form.demographics.age.label(class="form-label") }}
+              {{ form.demographics.age(class="form-control", placeholder="e.g. 54") }}
+            </div>
+            <div class="col-md-6 mb-3">
+              {{ form.demographics.sex.label(class="form-label") }}
+              {{ form.demographics.sex(class="form-select") }}
+            </div>
+          </div>
+          <div class="mb-3">
+            {{ form.demographics.clinical_notes.label(class="form-label") }}
+            {{ form.demographics.clinical_notes(class="form-control", rows=3) }}
+          </div>
+        </section>
+
+        <section class="mb-4">
+          <h2 class="h4">Pathology</h2>
+          <div class="mb-3">
+            {{ form.pathology.tumour_type.label(class="form-label") }}
+            {{ form.pathology.tumour_type(class="form-control") }}
+          </div>
+          <div class="mb-3">
+            {{ form.pathology.stage.label(class="form-label") }}
+            {{ form.pathology.stage(class="form-control") }}
+          </div>
+          <div class="mb-3">
+            {{ form.pathology.receptor_status.label(class="form-label") }}
+            {{ form.pathology.receptor_status(class="form-control", rows=3) }}
+          </div>
+        </section>
+
+        <section class="mb-4">
+          <h2 class="h4">Genomics</h2>
+          <div class="mb-3">
+            {{ form.genomics.sequencing_platform.label(class="form-label") }}
+            {{ form.genomics.sequencing_platform(class="form-control") }}
+          </div>
+          <div class="mb-3">
+            {{ form.genomics.variants.label(class="form-label") }}
+            {{ form.genomics.variants(class="form-control", rows=4) }}
+          </div>
+        </section>
+
+        <button type="submit" class="btn btn-primary">{{ form.submit.label.text }}</button>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,38 @@
+"""Application configuration objects."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+class BaseConfig:
+    """Base configuration shared across environments."""
+
+    SECRET_KEY = os.environ.get("FLASK_SECRET_KEY", "dev-secret-key")
+    OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+    WTF_CSRF_ENABLED = True
+
+    # Folders used by the prototype. Paths are resolved relative to project root.
+    PROJECT_ROOT = Path(__file__).resolve().parent
+    DATA_DIR = PROJECT_ROOT / "data"
+    VECTOR_STORE_DIR = PROJECT_ROOT / "vector_store"
+
+
+class DevelopmentConfig(BaseConfig):
+    DEBUG = True
+
+
+class TestingConfig(BaseConfig):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+
+
+class ProductionConfig(BaseConfig):
+    DEBUG = False
+
+
+CONFIG_MAP = {
+    "development": DevelopmentConfig,
+    "testing": TestingConfig,
+    "production": ProductionConfig,
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=3.0,<4.0
+Flask-WTF>=1.2,<2.0
+python-dotenv>=1.0,<2.0

--- a/run.py
+++ b/run.py
@@ -1,0 +1,10 @@
+"""Entrypoint for running the Flask development server."""
+from __future__ import annotations
+
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=app.config.get("DEBUG", False))


### PR DESCRIPTION
## Summary
- scaffold a Flask application factory with configuration and routing hooks
- add WTForms-based intake form templates covering EHR, pathology, and genomics sections
- document setup steps and add dependency, environment, and ignore files for local development

## Testing
- not run (project scaffolding only)


------
https://chatgpt.com/codex/tasks/task_e_68d68249339483279f33d389aec2aea2